### PR TITLE
Add "reconnect" time variable to config.

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -44,6 +44,7 @@ setting("bool",   "send_join_part", true) -- Whether to send player join and par
 setting("string", "password") -- Server password
 setting("bool",   "secure", false) -- Enable a TLS connection, requires LuaSEC
 setting("number", "timeout", 60) -- Underlying socket timeout in seconds.
+setting("number", "reconnect", 600) -- Reconnect in seconds after timeout.
 setting("string", "command_prefix") -- Prefix to use for bot commands
 setting("bool",   "debug", false) -- Enable debug output
 setting("bool",   "enable_player_part", true) -- Whether to enable players joining and parting the channel

--- a/init.lua
+++ b/init.lua
@@ -107,6 +107,7 @@ function irc:connect()
 			port = self.config.port,
 			password = self.config.password,
 			timeout = self.config.timeout,
+			reconnect = self.config.reconnect,
 			secure = self.config.secure
 		})
 	end)
@@ -114,7 +115,7 @@ function irc:connect()
 	if not good then
 		minetest.log("error", ("IRC: Connection error: %s: %s -- Reconnecting in ten minutes...")
 					:format(self.config.server, message))
-		minetest.after(600, function() self:connect() end)
+		minetest.after(reconnect, function() self:connect() end)
 		return
 	end
 

--- a/init.lua
+++ b/init.lua
@@ -115,7 +115,7 @@ function irc:connect()
 	if not good then
 		minetest.log("error", ("IRC: Connection error: %s: %s -- Reconnecting in ten minutes...")
 					:format(self.config.server, message))
-		minetest.after(reconnect, function() self:connect() end)
+		minetest.after(self.config.reconnect, function() self:connect() end)
 		return
 	end
 


### PR DESCRIPTION
Allow server admin to specify how long until a reconnect occurs after a timeout (default 600 seconds) without having to modify the core code.