### PR TITLE
Report when players time out instead of leaving normally.

### DIFF
--- a/callback.lua
+++ b/callback.lua
@@ -10,10 +10,11 @@ minetest.register_on_joinplayer(function(player)
 end)
 
 
-minetest.register_on_leaveplayer(function(player)
+minetest.register_on_leaveplayer(function(player, timed_out)
 	local name = player:get_player_name()
 	if irc.connected and irc.config.send_join_part then
-		irc:say("*** "..name.." left the game")
+		irc:say("*** "..name.." left the game"..
+				(timed_out and " (Timed out)" or ""))
 	end
 end)
 


### PR DESCRIPTION
Requires minetest/minetest#3537 (merged 2016-06-11) for new functionality. Old servers are supported and unaffected.