### PR TITLE
Avoid 21 deprecation warnings

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -7,11 +7,11 @@ irc.config = {}
 local function setting(stype, name, default, required)
 	local value
 	if stype == "bool" then
-		value = minetest.setting_getbool("irc."..name)
+		value = minetest.settings:get_bool("irc."..name)
 	elseif stype == "string" then
-		value = minetest.setting_get("irc."..name)
+		value = minetest.settings:get("irc."..name)
 	elseif stype == "number" then
-		value = tonumber(minetest.setting_get("irc."..name))
+		value = tonumber(minetest.settings:get("irc."..name))
 	end
 	if value == nil then
 		if required then

--- a/config.lua
+++ b/config.lua
@@ -6,12 +6,24 @@ irc.config = {}
 
 local function setting(stype, name, default, required)
 	local value
-	if stype == "bool" then
-		value = minetest.settings:get_bool("irc."..name)
-	elseif stype == "string" then
-		value = minetest.settings:get("irc."..name)
-	elseif stype == "number" then
-		value = tonumber(minetest.settings:get("irc."..name))
+	if minetest.settings and minetest.settings.get and minetest.settings.get_bool then
+		-- The current methods for getting settings
+		if stype == "bool" then
+			value = minetest.settings:get_bool("irc."..name)
+		elseif stype == "string" then
+			value = minetest.settings:get("irc."..name)
+		elseif stype == "number" then
+			value = tonumber(minetest.settings:get("irc."..name))
+		end
+	else
+		-- The old methods for getting settings for backward compatibility. Deprecated on 0.4.16+
+		if stype == "bool" then
+			value = minetest.setting_getbool("irc."..name)
+		elseif stype == "string" then
+			value = minetest.setting_get("irc."..name)
+		elseif stype == "number" then
+			value = tonumber(minetest.setting_get("irc."..name))
+		end	
 	end
 	if value == nil then
 		if required then


### PR DESCRIPTION
This change avoids 21 deprecation warnings in debug.txt on every server start

2018-05-29 23:46:10: WARNING[Main]: WARNING: minetest.setting_* functions are deprecated.  Use methods on the minetest.settings object.