### PR TITLE
Add support for configurable coloring of IRC messages in-game

### DIFF
--- a/botcmds.lua
+++ b/botcmds.lua
@@ -51,7 +51,8 @@ function irc.bot_command(msg, text)
 			return
 		end
 		minetest.chat_send_player(player_to,
-				"PM from "..msg.user.nick.."@IRC: "..message, false)
+				minetest.colorize(irc.config.pm_color,
+				"PM from "..msg.user.nick.."@IRC: "..message, false))
 		irc.reply("Message sent!")
 		return
 	end

--- a/config.lua
+++ b/config.lua
@@ -23,7 +23,7 @@ local function setting(stype, name, default, required)
 			value = minetest.setting_get("irc."..name)
 		elseif stype == "number" then
 			value = tonumber(minetest.setting_get("irc."..name))
-		end	
+		end
 	end
 	if value == nil then
 		if required then
@@ -65,4 +65,5 @@ setting("bool",   "debug", false) -- Enable debug output
 setting("bool",   "enable_player_part", true) -- Whether to enable players joining and parting the channel
 setting("bool",   "auto_join", true) -- Whether to automatically show players in the channel when they join
 setting("bool",   "auto_connect", true) -- Whether to automatically connect to the server on mod load
-
+setting("string", "chat_color", "#339933") -- Color of IRC chat in-game, green by default
+setting("string", "pm_color", "#8800AA") -- Color of IRC PMs in-game, purple by default

--- a/messages.lua
+++ b/messages.lua
@@ -8,7 +8,7 @@ function irc.logChat(message)
 end
 
 function irc.sendLocal(message)
-	minetest.chat_send_all(message)
+	minetest.chat_send_all(minetest.colorize(irc.config.chat_color, message))
 	irc.logChat(message)
 end
 

--- a/player_part.lua
+++ b/player_part.lua
@@ -63,7 +63,8 @@ end)
 
 function irc.sendLocal(message)
 	for name, _ in pairs(irc.joined_players) do
-		minetest.chat_send_player(name, message)
+		minetest.chat_send_player(name,
+					minetest.colorize(irc.config.chat_color, message))
 	end
 	irc.logChat(message)
 end


### PR DESCRIPTION
- IRC channel messages make use of the `irc.char_color` setting in minetest.conf.
  - Defaults to `#339933` (green).
- IRC PMs make use of the `irc.pm_color` setting in minetest.conf.
  - Defaults to `#8800AA` (purple).

Continued from #46, since I accidentally deleted its corresponding branch :)