### PR TITLE
Fix message when a player on another server times out

### DIFF
--- a/hooks.lua
+++ b/hooks.lua
@@ -120,6 +120,8 @@ function irc.hooks.channelChat(msg)
 		text:find("^%*%*%* ([^%s]+) joined the game$")
 	local foundleave, _, leavenick =
 		text:find("^%*%*%* ([^%s]+) left the game$")
+	local foundtimedout, _, timedoutnick =
+		text:find("^%*%*%* ([^%s]+) left the game %(Timed out%)$")
 	local foundaction, _, actionnick, actionmessage =
 		text:find("^%* ([^%s]+) (.*)$")
 
@@ -134,6 +136,9 @@ function irc.hooks.channelChat(msg)
 	elseif foundleave then
 		irc.sendLocal(("*** %s left %s")
 				:format(leavenick, msg.user.nick))
+	elseif foundtimedout then
+		irc.sendLocal(("*** %s left %s (Timed out)")
+				:format(timedoutnick, msg.user.nick))
 	elseif foundaction then
 		irc.sendLocal(("* %s@%s %s")
 				:format(actionnick, msg.user.nick, actionmessage))


### PR DESCRIPTION
Replaces

`<Server@IRC> *** player left the game (Timed out)`

with

`*** player left Server (Timed out)`