### PR TITLE
Display total number of players with /who

### DIFF
--- a/player_part.lua
+++ b/player_part.lua
@@ -47,7 +47,7 @@ minetest.register_chatcommand("who", {
 			out[n] = plname
 		end
 		table.sort(out)
-		return true, "Players in channel: "..table.concat(out, ", ")
+		return true, n.." player(s) in channel: "..table.concat(out, ", ")
 	end
 })
 


### PR DESCRIPTION
It would be nice to know the total number of players so that you don't have to count them manually.