### PR TITLE
Fixed the notice hook error

### DIFF
--- a/hooks.lua
+++ b/hooks.lua
@@ -171,7 +171,7 @@ end
 
 
 function irc.hooks.notice(user, target, message)
-	if user.nick and target == irc.config.channel then
+	if user and user.nick and target == irc.config.channel then
 		irc.sendLocal("-"..user.nick.."@IRC- "..message)
 	end
 end


### PR DESCRIPTION
Fixed the error where it cannot find an user at the notice hook. 
It happened when you get the `NOTICE * :*** Looking up your hostname and checking ident`
Because "*" is not in the "<nick>!<ident>@<host>"